### PR TITLE
removed deprecated lines (no longer using crossfilter, moment)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,14 +88,10 @@
     "moment": "^2.14.1"
   },
   "browser": {
-    "crossfilter": "node_modules/crossfilter/crossfilter.js",
-    "d3": "node_modules/d3/d3.js",
-    "moment": "node_modules/moment/moment.js"
+    "d3": "node_modules/d3/d3.js"
   },
   "browserify-shim": {
-    "crossfilter": "global:crossfilter",
-    "d3": "global:d3",
-    "moment": "global:moment"
+    "d3": "global:d3"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
similar to PR #61, but this PR is about the 'magic' plugins to make browserify work.